### PR TITLE
Fix isNodeModule and add tests

### DIFF
--- a/lib/parse-options.js
+++ b/lib/parse-options.js
@@ -3,8 +3,10 @@ import escodegen from 'escodegen';
 import { parseAndTraverse } from './ast-parsing.js';
 
 export const isNodeModule = filePath => {
-  const match = filePath.match(/$\.|\//);
-  return match === null;
+  // A Node module import will not begin with a relative or absolute path
+  // indicator. Scoped packages (e.g. @scope/pkg) should also be treated as
+  // node modules, so simply check the first character.
+  return !filePath.startsWith('.') && !filePath.startsWith('/');
 };
 
 const OBJECT_EXPRESSION = (properties = []) => ({

--- a/lib/parse-options.test.js
+++ b/lib/parse-options.test.js
@@ -1,0 +1,10 @@
+import test from 'ava';
+import { isNodeModule } from './parse-options.js';
+
+test('isNodeModule identifies node modules', t => {
+  t.true(isNodeModule('chalk'));
+  t.true(isNodeModule('@scope/pkg'));
+  t.false(isNodeModule('./local.js'));
+  t.false(isNodeModule('../relative.js'));
+  t.false(isNodeModule('/absolute/path.js'));
+});


### PR DESCRIPTION
## Summary
- correct scoped package detection in `isNodeModule`
- test `isNodeModule` behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b47a6632c832eba36d1266e32bb75